### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
+    namespace "com.chatbooks.fluttershy_standalone"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
for newer versions of the gradle plugin a namespace attribute is required.